### PR TITLE
lazy-load memcache module, fix module load error

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -9,6 +9,7 @@ The game server currently runs on nodejs v0.4.7 (but should run fine on the late
 - websocket
 - websocket-server
 - sanitizer
+- memcache (only if you want metrics)
 
 All of them can be installed via `npm install [module_name]`
 

--- a/server/js/main.js
+++ b/server/js/main.js
@@ -13,7 +13,7 @@ function main(config) {
         worlds = [],
         lastTotalPlayers = 0,
         checkPopulationInterval = setInterval(function() {
-            if(metrics.isReady) {
+            if(metrics && metrics.isReady) {
                 metrics.getTotalPlayers(function(totalPlayers) {
                     if(totalPlayers !== lastTotalPlayers) {
                         lastTotalPlayers = totalPlayers;
@@ -44,7 +44,7 @@ function main(config) {
                 }
             };
         
-        if(config.metrics_enabled) {
+        if(metrics) {
             metrics.getOpenWorldCount(function(open_world_count) {
                 // choose the least populated world among open worlds
                 world = _.min(_.first(worlds, open_world_count), function(w) { return w.playerCount; });
@@ -78,8 +78,7 @@ function main(config) {
         var world = new WorldServer('world'+ (i+1), config.nb_players_per_world, server);
         world.run(config.map_filepath);
         worlds.push(world);
-        
-        if(config.metrics_enabled) {
+        if(metrics) {
             world.onPlayerAdded(onPopulationChange);
             world.onPlayerRemoved(onPopulationChange);
         }

--- a/server/js/metrics.js
+++ b/server/js/metrics.js
@@ -1,14 +1,13 @@
 
 var cls = require("./lib/class"),
-    _ = require("underscore"),
-    memcache = require("memcache");
+    _ = require("underscore");
 
 module.exports = Metrics = Class.extend({
     init: function(config) {
         var self = this;
         
         this.config = config;
-        this.client = new memcache.Client(config.memcached_port, config.memcached_host),
+        this.client = new require("memcache").Client(config.memcached_port, config.memcached_host),
         this.client.connect();
         this.isReady = false;
         


### PR DESCRIPTION
Don't require that the memcache module is installed if metrics_enabled=false.

Fixes this module load error:

```
$ node server/js/main.js 

node.js:197
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
Error: Cannot find module 'memcache'
    at Function._resolveFilename (module.js:332:15)
    at Function._load (module.js:279:25)
    at Module.require (module.js:356:17)
    at require (module.js:372:17)
    at Object.<anonymous> (/home/bnoordhuis/src/BrowserQuest/server/js/metrics.js:4:16)
    at Module._compile (module.js:443:26)
    at Object..js (module.js:461:10)
    at Module.load (module.js:350:32)
    at Function._load (module.js:308:12)
    at Module.require (module.js:356:17)
```
