### PR TITLE
build: make build.sh independent of $PWD

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -2,21 +2,30 @@
 
 # Script to generate an optimized client build of BrowserQuest
 
-BUILDDIR="../client-build"
-PROJECTDIR="../client/js"
-CURDIR=$(pwd)
+TOPLEVELDIR="`dirname $0`/.."
+BUILDDIR="$TOPLEVELDIR/client-build"
+PROJECTDIR="$TOPLEVELDIR/client/js"
 
 
 echo "Deleting previous build directory"
 rm -rf $BUILDDIR
 
 echo "Building client with RequireJS"
-cd $PROJECTDIR
-node ../../bin/r.js -o build.js
-cd $CURDIR
+node $TOPLEVELDIR/bin/r.js -o $PROJECTDIR/build.js
 
 echo "Removing unnecessary js files from the build directory"
-find $BUILDDIR/js -type f -not \( -name "game.js" -o -name "home.js" -o -name "log.js" -o -name "require-jquery.js" -o -name "modernizr.js" -o -name "css3-mediaqueries.js" -o -name "mapworker.js" -o -name "detect.js" -o -name "underscore.min.js" -o -name "text.js" \) -delete
+find $BUILDDIR/js -type f \
+  -not \( -name "game.js" \
+  -o -name "home.js" \
+  -o -name "log.js" \
+  -o -name "require-jquery.js" \
+  -o -name "modernizr.js" \
+  -o -name "css3-mediaqueries.js" \
+  -o -name "mapworker.js" \
+  -o -name "detect.js" \
+  -o -name "underscore.min.js" \
+  -o -name "text.js" \) \
+  -delete
 
 echo "Removing sprites directory"
 rm -rf $BUILDDIR/sprites
@@ -25,6 +34,6 @@ echo "Removing config directory"
 rm -rf $BUILDDIR/config
 
 echo "Moving build.txt to current dir"
-mv $BUILDDIR/build.txt $CURDIR
+mv $BUILDDIR/build.txt $TOPLEVELDIR
 
 echo "Build complete"


### PR DESCRIPTION
Users no longer need to `cd /path/to/BrowserQuest/bin && ./build.sh`, now `/path/to/BrowserQuest/bin/build.sh` is sufficient.
