### PR TITLE
Add memcache as a node requirement in server/README.md.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "BrowserQuest",
+  "version": "0.1.0", 
+  "scripts": {"start": "node server/js/main.js"},
+  "dependencies": 
+    {"underscore": "1.x",
+     "log": "1.x",
+     "bison": "1.x",
+     "websocket": "1.x",
+     "websocket-server": "1.x",
+     "sanitizer": "0.x",
+     "memcache": "0.x"}
+}

--- a/server/README.md
+++ b/server/README.md
@@ -9,6 +9,7 @@ The game server currently runs on nodejs v0.4.7 (but should run fine on the late
 - websocket
 - websocket-server
 - sanitizer
+- memcache
 
 All of them can be installed via `npm install [module_name]`
 


### PR DESCRIPTION
When trying to run the BrowserQuest server, node indicates that memcache is a necessary dependency.

```
> node server/js/main.js 

node.js:201
      throw e; // process.nextTick error, or 'error' event on first tick
          ^
Error: Cannot find module 'memcache'
```

I propose adding this as a requirement in the server/README.md.
