### PR TITLE
Add memcache to the list of dependencies.

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -9,6 +9,7 @@ The game server currently runs on nodejs v0.4.7 (but should run fine on the late
 - websocket
 - websocket-server
 - sanitizer
+- memcache
 
 All of them can be installed via `npm install [module_name]`
 


### PR DESCRIPTION
When I first tried to run the server on node v.0.6.11, I got an error

```
Error: Cannot find module 'memcache'
at Function._resolveFilename (module.js:332:11)
at Function._load (module.js:279
```

`npm install -g memcache` fixes this.
