### PR TITLE
World chat and framework for chat commands

### DIFF
--- a/client/js/game.js
+++ b/client/js/game.js
@@ -1459,8 +1459,10 @@ function(InfoManager, BubbleManager, Renderer, Map, Animation, Sprite, AnimatedT
             
                 self.client.onChatMessage(function(entityId, message) {
                     var entity = self.getEntityById(entityId);
-                    self.createBubble(entityId, message);
-                    self.assignBubbleTo(entity);
+                    if(!self.parseChatCommands(entity, message)) {
+                        self.createBubble(entityId, message);
+                        self.assignBubbleTo(entity);
+                    }
                     self.audioManager.playSound("chat");
                 });
             
@@ -2447,6 +2449,24 @@ function(InfoManager, BubbleManager, Renderer, Map, Animation, Sprite, AnimatedT
                     this.renderer.targetRect = targetRect;
                 }
             }
+        },
+
+        /**
+         * Handles special chat commands.  Return true to disable chat bubble.
+         *
+         * @param entity
+         * @param message
+         * @return boolean
+         */
+        parseChatCommands: function(entity, message) {
+            switch (message.substr(0, 3)) {
+                case '/w ':
+                    chatMessage = entity.name + ": " + message.substr(3);
+                    log.debug("/w " + chatMessage);
+                    this.showNotification(chatMessage);
+                    return true;
+            }
+            return false;
         }
     });
     

--- a/server/js/player.js
+++ b/server/js/player.js
@@ -79,7 +79,7 @@ module.exports = Player = Character.extend({
                 // Sanitized messages may become empty. No need to broadcast empty chat messages.
                 if(msg && msg !== "") {
                     msg = msg.substr(0, 60); // Enforce maxlength of chat input
-                    self.broadcastToZone(new Messages.Chat(self, msg), false);
+                    self.broadcast(new Messages.Chat(self, msg), false);
                 }
             }
             else if(action === Types.Messages.MOVE) {


### PR DESCRIPTION
I've updated the client CHAT command to parse the message for special commands.

The one command added is a "/w " which instead of creating a chat bubble to the local zone, it sends the message as a notification to the world.

However, to accomplish this, on the server side I had to change the player chat listener from sending broadcastToZone, to just broadcast.  I'm not 100% sure of the ramifications of doing this, and if there is a better way (or cleaner) please let me know and I will update the pull request.
