### PR TITLE
World chat and framework for chat commands

### DIFF
--- a/client/js/game.js
+++ b/client/js/game.js
@@ -1459,8 +1459,10 @@ function(InfoManager, BubbleManager, Renderer, Map, Animation, Sprite, AnimatedT
             
                 self.client.onChatMessage(function(entityId, message) {
                     var entity = self.getEntityById(entityId);
-                    self.createBubble(entityId, message);
-                    self.assignBubbleTo(entity);
+                    if(!self.parseChatCommands(entity, message)) {
+                        self.createBubble(entityId, message);
+                        self.assignBubbleTo(entity);
+                    }
                     self.audioManager.playSound("chat");
                 });
             
@@ -2447,6 +2449,24 @@ function(InfoManager, BubbleManager, Renderer, Map, Animation, Sprite, AnimatedT
                     this.renderer.targetRect = targetRect;
                 }
             }
+        },
+
+        /**
+         * Handles special chat commands.  Return true to disable chat bubble.
+         *
+         * @param entity
+         * @param message
+         * @return boolean
+         */
+        parseChatCommands: function(entity, message) {
+            switch (message.substr(0, 3)) {
+                case '/w ':
+                    chatMessage = entity.name + ": " + message.substr(3);
+                    log.debug("/w " + chatMessage);
+                    this.showNotification(chatMessage);
+                    return true;
+            }
+            return false;
         }
     });
     

--- a/client/js/game.js
+++ b/client/js/game.js
@@ -55,6 +55,11 @@ function(InfoManager, BubbleManager, Renderer, Map, Animation, Sprite, AnimatedT
             this.cursors = {};
 
             this.sprites = {};
+
+            // Global chats
+            this.chats = 0;
+            this.maxChats = 6;
+            this.globalChatColor = '#A6FFF9';
         
             // tile animation
             this.animatedTiles = null;
@@ -2225,9 +2230,30 @@ function(InfoManager, BubbleManager, Renderer, Map, Animation, Sprite, AnimatedT
                 }
             
                 y = ((character.y - this.camera.y) * s) - (t * 2) - offsetY;
-            
                 bubble.element.css('left', x - offset + 'px');
                 bubble.element.css('top', y + 'px');
+            }
+        },
+
+        assignGlobalBubble: function(id) {
+            var bubble = this.bubbleManager.getBubbleById(id);
+
+            if(bubble) {
+                if(this.chats >= this.maxChats) {
+                    this.chats = 0;
+                }
+                var s = this.renderer.scale,
+                    ts = 16,
+                    t = ts * s,
+                    startX = t * 27,
+                    startY = t * 10,
+                    x = (this.camera.gridW - 2) * t - startX,
+                    y = (this.camera.gridH - 2) * t - startY;
+                y = y + (this.chats++ * t * 2);
+
+                bubble.element.css('left', x + 'px');
+                bubble.element.css('top', y + 'px');
+                bubble.element.css('color', this.globalChatColor);
             }
         },
     
@@ -2452,7 +2478,7 @@ function(InfoManager, BubbleManager, Renderer, Map, Animation, Sprite, AnimatedT
         },
 
         /**
-         * Handles special chat commands.  Return true to disable chat bubble.
+         * Handles special chat commands.  Return true to disable character chat bubble.
          *
          * @param entity
          * @param message
@@ -2463,7 +2489,9 @@ function(InfoManager, BubbleManager, Renderer, Map, Animation, Sprite, AnimatedT
                 case '/w ':
                     chatMessage = entity.name + ": " + message.substr(3);
                     log.debug("/w " + chatMessage);
-                    this.showNotification(chatMessage);
+                    messageId = Math.floor(Math.random() * 10000);
+                    this.createBubble(messageId, chatMessage);
+                    this.assignGlobalBubble(messageId);
                     return true;
             }
             return false;

--- a/server/js/player.js
+++ b/server/js/player.js
@@ -79,7 +79,7 @@ module.exports = Player = Character.extend({
                 // Sanitized messages may become empty. No need to broadcast empty chat messages.
                 if(msg && msg !== "") {
                     msg = msg.substr(0, 60); // Enforce maxlength of chat input
-                    self.broadcastToZone(new Messages.Chat(self, msg), false);
+                    self.broadcast(new Messages.Chat(self, msg), false);
                 }
             }
             else if(action === Types.Messages.MOVE) {


### PR DESCRIPTION
I've updated the client CHAT command to parse the message for special commands.

The one command added is a "/w " which instead of creating a chat bubble to the player, it creates a static chat bubble off to the side with a different color.

However, to accomplish this, on the server side I had to change the player chat listener from sending broadcastToZone, to just broadcast. I'm not 100% sure of the ramifications of doing this, and if there is a better way (or cleaner) please let me know and I will update the pull request.
