### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   , "version": "0.0.1"
   , "private": false 
   , "dependencies": {
-    "underscore": ">0"
-    , "log": ">0"
-    , "bison": ">0"
-    , "websocket": ">0"
-    , "websocket-server": ">0"
-    , "sanitizer": ">0"
-    , "memcache": ">0"
+    "underscore": "*"
+    , "log": "*"
+    , "bison": "*"
+    , "websocket": "*"
+    , "websocket-server": "*"
+    , "sanitizer": "*"
+    , "memcache": "*"
   }
 }


### PR DESCRIPTION
The original package.json uses '>0', which will generates errors during npm install(eg. No compatible version found: sanitizer@'>=1.0.0-0').
