### PR TITLE
Fix package.json bitrot.

### DIFF
--- a/bin/r.js
+++ b/bin/r.js
@@ -88,7 +88,7 @@ var requirejs, require, define;
         };
 
         exists = function (fileName) {
-            return path.existsSync(fileName);
+            return fs.existsSync(fileName);
         };
 
 
@@ -2218,7 +2218,7 @@ var requirejs, require, define;
         context.loaded[moduleName] = false;
         context.scriptCount += 1;
 
-        if (path.existsSync(url)) {
+        if (fs.existsSync(url)) {
             contents = fs.readFileSync(url, 'utf8');
 
             contents = req.makeNodeWrapper(contents);

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-    "name": "BrowserQuest"
+  "name": "BrowserQuest"
   , "version": "0.0.1"
-  , "private": false 
+  , "private": false
   , "dependencies": {
-    "underscore": ">0"
-    , "log": ">0"
-    , "bison": ">0"
-    , "websocket": ">0"
-    , "websocket-server": ">0"
-    , "sanitizer": ">0"
-    , "memcache": ">0"
+    "underscore": "latest"
+    , "log": "latest"
+    , "bison": "latest"
+    , "websocket": "latest"
+    , "websocket-server": "git://github.com/miksago/node-websocket-server#dae6bed226ccfccf3939973155570b39dc8b3df0"
+    , "sanitizer": "latest"
+    , "memcache": "latest"
   }
 }

--- a/server/js/map.js
+++ b/server/js/map.js
@@ -12,7 +12,7 @@ module.exports = Map = cls.Class.extend({
     
     	this.isLoaded = false;
     
-    	path.exists(filepath, function(exists) {
+        fs.exists(filepath, function(exists) {
             if(!exists) {
                 log.error(filepath + " doesn't exist.");
                 return;

--- a/tools/maps/exportmap.js
+++ b/tools/maps/exportmap.js
@@ -47,7 +47,7 @@ function main() {
 function getTiledJSONmap(filename, callback) {
     var self = this;
     
-    path.exists(filename, function(exists) {
+    fs.exists(filename, function(exists) {
         if(!exists) {  
             log.error(filename + " doesn't exist.")
             return;


### PR DESCRIPTION
Most importantly, node-websocket-server has been unpublished from npm
and now fails to install. BrowserQuest really ought to be ported to the
'ws' package which supersedes websocket and websocket-server, but for
now the server code can continue to function by installing
websocket-server directly from GitHub.

I also encountered issues with version numbers for 'sanitizer' and
'memcache', which depending on the version 'latest' seems to solve.
